### PR TITLE
exclude browser stress tests from default ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: dotnet playwright -p Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj install chromium
 
     - name: Test
-      run: dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage"
+      run: dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category!=BrowserStress" --collect:"XPlat Code Coverage"
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       run: dotnet playwright -p Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj install chromium
 
     - name: Test
-      run: dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --no-build --verbosity normal
+      run: dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --no-build --verbosity normal --filter "Category!=BrowserStress"
 
     - name: Pack NuGet packages
       run: dotnet pack ManagedCode.Storage.slnx --configuration Release --no-build -p:IncludeSymbols=false -p:SymbolPackageFormat=snupkg --output ./artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,4 +327,5 @@ Ask first:
 ### Dislikes
 
 - Template-generated scaffolding in tests; keep test hosts and verification surfaces minimal, hand-written, and purpose-built.
+- CI regressions that inflate `build-and-test` far beyond the historical baseline; browser large-file coverage must stay meaningful without turning the default GitHub Actions path into a 30+ minute run.
 - Unnecessary product-code fallbacks; prefer one clear production path unless backward compatibility is an explicit requirement for the task.

--- a/Tests/ManagedCode.Storage.Tests/Storages/Browser/BrowserServerStorageIntegrationTests.cs
+++ b/Tests/ManagedCode.Storage.Tests/Storages/Browser/BrowserServerStorageIntegrationTests.cs
@@ -57,6 +57,7 @@ public sealed class BrowserServerStorageIntegrationTests(BrowserServerHostFixtur
 
     [Fact]
     [Trait("Category", "LargeFile")]
+    [Trait("Category", "BrowserStress")]
     public async Task BrowserStorage_ServerHost_LargeFlow_ShouldPersistAcrossPages()
     {
         const int chunkedPayloadSizeMiB = 1024;

--- a/Tests/ManagedCode.Storage.Tests/Storages/Browser/BrowserWasmStorageIntegrationTests.cs
+++ b/Tests/ManagedCode.Storage.Tests/Storages/Browser/BrowserWasmStorageIntegrationTests.cs
@@ -57,6 +57,7 @@ public sealed class BrowserWasmStorageIntegrationTests(BrowserWasmHostFixture fi
 
     [Fact]
     [Trait("Category", "LargeFile")]
+    [Trait("Category", "BrowserStress")]
     public async Task BrowserStorage_WasmHost_LargeFlow_ShouldPersistAcrossPages()
     {
         const int chunkedPayloadSizeMiB = 1024;

--- a/docs/Development/setup.md
+++ b/docs/Development/setup.md
@@ -57,5 +57,6 @@ dotnet format ManagedCode.Storage.slnx
 
 - Start Docker Desktop (or your Docker daemon) before running the full test suite.
 - AWS and Orleans integration tests intentionally pin LocalStack to `localstack/localstack:4.14.0`; do not switch them back to `latest`, because the end-of-March 2026 `latest` image became auth-gated and breaks CI without a token.
+- GitHub Actions `build-and-test` and `Release` intentionally exclude `Category=BrowserStress`; run that browser-hosted `1 GiB` stress lane locally with `dotnet test ... --filter "Category=BrowserStress"` when you specifically need it.
 - Never commit secrets (cloud keys, OAuth tokens, connection strings). Use environment variables or user secrets.
 - Credentials for cloud-drive providers are documented in `docs/Development/credentials.md`.

--- a/docs/Testing/strategy.md
+++ b/docs/Testing/strategy.md
@@ -56,6 +56,7 @@ Where possible, tests run without real cloud accounts:
 Some tests are marked as “large file” to validate streaming behaviour:
 
 - `[Trait("Category", "LargeFile")]`
+- Browser-hosted `1 GiB` stress flows also carry `[Trait("Category", "BrowserStress")]`.
 
 Run everything (canonical):
 
@@ -76,6 +77,20 @@ Skip large-file tests when iterating:
 ```bash
 dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --filter "Category!=LargeFile"
 ```
+
+Skip the hosted-browser stress lane while still running the default fast browser coverage:
+
+```bash
+dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --filter "Category!=BrowserStress"
+```
+
+Run only the hosted-browser `1 GiB` stress lane locally when you explicitly need it:
+
+```bash
+dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --filter "Category=BrowserStress"
+```
+
+GitHub-hosted `build-and-test` and `Release` workflows intentionally exclude `Category=BrowserStress` so mainline CI stays near the historical runtime instead of spending 30+ minutes on Chromium-hosted `1 GiB` OPFS stress flows that are not stable on shared runners.
 
 ## Quality Rules
 


### PR DESCRIPTION
## Summary
- tag the hosted-browser 1 GiB Playwright flows as BrowserStress
- exclude BrowserStress from the default build-and-test and Release workflows
- document that BrowserStress remains an explicit local verification lane instead of a default GitHub-hosted runner check

## Verification
- dotnet test Tests/ManagedCode.Storage.Tests/ManagedCode.Storage.Tests.csproj --configuration Release --filter "Category!=BrowserStress"
- dotnet format ManagedCode.Storage.slnx
- dotnet build ManagedCode.Storage.slnx